### PR TITLE
Wrong value for PidTagCurrentDraftEntryId

### DIFF
--- a/msg/src/main/java/io/github/jmcleodfoss/msg/PropertyTags.java
+++ b/msg/src/main/java/io/github/jmcleodfoss/msg/PropertyTags.java
@@ -12,7 +12,7 @@ package io.github.jmcleodfoss.msg;
 @SuppressWarnings("PMD.ExcessiveClassLength")
 public class PropertyTags
 {
-	static final public int PidTagCurrentDraftEntryId = 0102;
+	static final public int PidTagCurrentDraftEntryId = 0x0102;
 	static final public int PidTagTemplateData = 0x00010102;
 	static final public int PidTagAlternateRecipientAllowed = 0x0002000b;
 	static final public int PidTagScriptData = 0x00040102;


### PR DESCRIPTION
There is a mistake in the `PropertyTags` class, the `PidTagCurrentDraftEntryId` constant has an octal value instead of an hexadecimal value.